### PR TITLE
Next Release 4.2.0

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,41 @@
+name: PHPUnit
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*.*.*"
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 8 * * 1"
+
+jobs:
+  Build:
+    runs-on: 'ubuntu-latest'
+    container: 'byjg/php:${{ matrix.php-version }}-cli'
+    strategy:
+      matrix:
+        php-version:
+          - "8.1"
+          - "8.0"
+          - "7.4"
+          - "7.3"
+          - "7.2"
+          - "7.1"
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: composer install
+      - run: ./vendor/bin/phpunit
+
+  Documentation:
+    runs-on: 'ubuntu-latest'
+    needs: Build
+    if: github.ref == 'refs/heads/master'
+    env:
+      DOC_GITHUB_TOKEN: '${{ secrets.DOC_TOKEN }}'
+    steps:
+      - uses: actions/checkout@v2
+      - run: curl https://opensource.byjg.com/add-doc.sh | bash /dev/stdin php anydata-text

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor
 
 node_modules
 .usdocker
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ See more about Anydataset [here](https://opensource.byjg.com/anydataset).
 
 ### Text File Delimited (CSV)
 
+This type of files uses a delimiter to define each field. The most common formart is CSV but you can use your own based on a regular expression.
+The class TextFileIterator has three constants with pre-defined formats:
+
+    - TextFileDataset::CSVFILE - A generic file definition. It accept both `,` and `;` as delimiter. 
+    - TextFileDataset::CSVFILE_COMMA - The CSV file. It accept only `,` as delimiter. 
+    - TextFileDataset::CSVFILE_SEMICOLON - A CSV variation. It accept only `;` as delimiter. 
+
 ```php
 <?php
 $file = "Joao;Magalhaes
@@ -52,6 +59,33 @@ foreach ($iterator as $row) {
 
 ### Text File Fixed sized columns
 
+This file has the field defined by it position on the line. It is necessary to define the name, type, position and field length for each field to to parse the file.
+This definition also allows set up required values and sub-types based on a value.
+
+The field definition is created by the enum `FixedTextDefinition` and it has the following fields:
+
+```php
+$definition = new FixedTextDefinition(
+    $fieldName,      # The field name
+    $startPos,       # The start position of this field in the row
+    $length,         # The number of characteres of the field content
+    $type,           # (optional) The type of the field content. FixedTextDefinition::TYPE_NUMBER or FixedTextDefinition::TYPE_STRING (default)
+    $requiredValue,  # (optional) an array of valid values. E.g. ['Y', 'N']
+    $subTypes = array(), # An associative array of FixedTextDefinition. If the value matches with the key of the associative array, then a sub set
+                         # of FixedTextDefinition is processed. e.g.
+                         # [
+                         #    "Y" => [
+                         #      new FixedTextDefinition(...),
+                         #      new FixedTextDefinition(...),
+                         #    ],
+                         #    "N" => new FixedTextDefinition(...)
+                         # ]
+);
+```
+
+Example:
+
+
 ```php
 <?php
 $file = "".
@@ -59,10 +93,10 @@ $file = "".
     "002GILBERTS1621\n";
 
 $fieldDefinition = [
-    new \ByJG\AnyDataset\Text\Enum\FixedTextDefinition('id', 0, 3),
-    new \ByJG\AnyDataset\Text\Enum\FixedTextDefinition('name', 3, 7),
-    new \ByJG\AnyDataset\Text\Enum\FixedTextDefinition('enable', 10, 1, 'S|N'), // Required value --> S or N
-    new \ByJG\AnyDataset\Text\Enum\FixedTextDefinition('code', 11, 4),
+    new \ByJG\AnyDataset\Text\Enum\FixedTextDefinition('id', 0, 3, FixedTextDefinition::TYPE_NUMBER),
+    new \ByJG\AnyDataset\Text\Enum\FixedTextDefinition('name', 3, 7, FixedTextDefinition::TYPE_STRING),
+    new \ByJG\AnyDataset\Text\Enum\FixedTextDefinition('enable', 10, 1, FixedTextDefinition::TYPE_STRING, ['S', 'N']), // Required values --> S or N
+    new \ByJG\AnyDataset\Text\Enum\FixedTextDefinition('code', 11, 4, FixedTextDefinition::TYPE_NUMBER),
 ];
 
 $dataset = new \ByJG\AnyDataset\Text\FixedTextFileDataset($file)
@@ -92,6 +126,7 @@ $fieldDefinition = [
         'enable',
         10,
         1,
+        FixedTextDefinition::TYPE_STRING,
         null,
         [
             "S" => [

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # AnyDataset-Text
 
+[![Build Status](https://github.com/byjg/anydataset-text/actions/workflows/phpunit.yml/badge.svg?branch=master)](https://github.com/byjg/anydataset-text/actions/workflows/phpunit.yml)
 [![Opensource ByJG](https://img.shields.io/badge/opensource-byjg-success.svg)](http://opensource.byjg.com)
 [![GitHub source](https://img.shields.io/badge/Github-source-informational?logo=github)](https://github.com/byjg/anydataset-text/)
 [![GitHub license](https://img.shields.io/github/license/byjg/anydataset-text.svg)](https://opensource.byjg.com/opensource/licensing.html)
 [![GitHub release](https://img.shields.io/github/release/byjg/anydataset-text.svg)](https://github.com/byjg/anydataset-text/releases/)
-[![Build Status](https://travis-ci.com/byjg/anydataset-text.svg?branch=master)](https://travis-ci.com/byjg/anydataset-text)
-
 
 Text file abstraction dataset. Anydataset is an agnostic data source abstraction layer in PHP. 
 
@@ -13,7 +12,7 @@ See more about Anydataset [here](https://opensource.byjg.com/anydataset).
 
 ## Examples
 
-### Text File Delimited
+### Text File Delimited (CSV)
 
 ```php
 <?php
@@ -32,7 +31,7 @@ foreach ($iterator as $row) {
 }
 ```
 
-### Text File Delimited - Get field names from first line
+### Text File Delimited (CSV) - Get field names from first line
 
 ```php
 <?php
@@ -66,10 +65,8 @@ $fieldDefinition = [
     new \ByJG\AnyDataset\Text\Enum\FixedTextDefinition('code', 11, 4),
 ];
 
-$dataset = new \ByJG\AnyDataset\Text\FixedTextFileDataset(
-    $file,
-    $fieldDefinition
-);
+$dataset = new \ByJG\AnyDataset\Text\FixedTextFileDataset($file)
+    ->withFieldDefinition($fieldDefinition);
 
 $iterator = $dataset->getIterator();
 foreach ($iterator as $row) {
@@ -108,10 +105,8 @@ $fieldDefinition = [
     ),
 ];
 
-$dataset = new \ByJG\AnyDataset\Text\FixedTextFileDataset(
-    $file,
-    $fieldDefinition
-);
+$dataset = new \ByJG\AnyDataset\Text\FixedTextFileDataset($file)
+    ->withFieldDefinition($fieldDefinition);
 
 $iterator = $dataset->getIterator();
 foreach ($iterator as $row) {
@@ -126,11 +121,11 @@ foreach ($iterator as $row) {
 
 ### Read from remote url
 
-`TextFileDataset` and `FixedTextFileDataset` support read file from remote http or https
+Both `TextFileDataset` and `FixedTextFileDataset` support read file from remote http or https
 
 ## Install
 
-Just type: `composer require "byjg/anydataset-text=4.0.*"`
+Just type: `composer require "byjg/anydataset-text=4.2.*"`
 
 ## Running Unit tests
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,33 @@ $file = "Joao;Magalhaes
 John;Doe
 Jane;Smith";
     
-$dataset = new \ByJG\AnyDataset\Text\TextFileDataset(
-    $file,
-    ["name", "surname"],
-    \ByJG\AnyDataset\Text\TextFileDataset::CSVFILE
-);
+$dataset = \ByJG\AnyDataset\Text\TextFileDataset::getInstance($file)
+    ->withFields(["name", "surname"])
+    ->withFieldParser(\ByJG\AnyDataset\Text\TextFileDataset::CSVFILE);
 $iterator = $dataset->getIterator();
 
 foreach ($iterator as $row) {
     echo $row->get('name');     // Print "Joao", "John", "Jane"
     echo $row->get('surname');  // Print "Magalhaes", "Doe", "Smith"
+}
+```
+
+### Text File Delimited - Get field names from first line
+
+```php
+<?php
+$file = "firstname;lastname
+John;Doe
+Jane;Smith";
+    
+// If omit `withFields` will get the field names from first line of the file
+$dataset = \ByJG\AnyDataset\Text\TextFileDataset::getInstance($file)
+    ->withFieldParser(\ByJG\AnyDataset\Text\TextFileDataset::CSVFILE);
+$iterator = $dataset->getIterator();
+
+foreach ($iterator as $row) {
+    echo $row->get('firstname');     // Print "John", "Jane"
+    echo $row->get('lastname');  // Print "Doe", "Smith"
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": ">=5.6.0",
-    "byjg/anydataset": "dev-master"
+    "byjg/anydataset": "4.1.*"
   },
   "require-dev": {
     "phpunit/phpunit": "5.7.*|7.4.*|^9.5"

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
   "minimum-stability": "dev",
   "require": {
     "php": ">=5.6.0",
-    "byjg/anydataset": "4.0.*"
+    "byjg/anydataset": "dev-master"
   },
   "require-dev": {
-    "phpunit/phpunit": "5.7.*|7.4.*"
+    "phpunit/phpunit": "5.7.*|7.4.*|^9.5"
   },
   "license": "MIT"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,12 @@ and open the template in the editor.
          convertWarningsToExceptions="true"
          stopOnFailure="false">
 
+    <php>
+        <ini name="display_errors" value="On" />
+        <ini name="display_startup_errors" value="On" />
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
+
     <filter>
         <whitelist>
             <directory>./src</directory>

--- a/src/Enum/FixedTextDefinition.php
+++ b/src/Enum/FixedTextDefinition.php
@@ -2,16 +2,21 @@
 
 namespace ByJG\AnyDataset\Text\Enum;
 
+use InvalidArgumentException;
+
 /**
  * @package xmlnuke
  */
 class FixedTextDefinition
 {
+    const TYPE_STRING = "string";
+    const TYPE_NUMBER = "number";
 
     public $fieldName;
     public $startPos;
     public $length;
     public $requiredValue;
+    public $type;
     public $subTypes = array();
 
     /**
@@ -19,15 +24,25 @@ class FixedTextDefinition
      * @param string $fieldName
      * @param int $startPos
      * @param int $length
-     * @param bool|string $requiredValue
+     * @param string $type
+     * @param array $requiredValue
      * @param FixedTextDefinition[] $subTypes
      */
-    public function __construct($fieldName, $startPos, $length, $requiredValue = "", $subTypes = null)
+    public function __construct($fieldName, $startPos, $length, $type = "string", $requiredValue = null, $subTypes = null)
     {
         $this->fieldName = $fieldName;
         $this->startPos = $startPos;
         $this->length = $length;
+        $this->type = $type;
         $this->requiredValue = $requiredValue;
         $this->subTypes = $subTypes;
+
+        if (!empty($this->requiredValue) && !is_array($this->requiredValue)) {
+            throw new InvalidArgumentException("Required Value must be empty or an ARRAY of values");
+        }
+
+        if ($this->type != self::TYPE_NUMBER && $this->type != self::TYPE_STRING) {
+            throw new InvalidArgumentException("Type must be '" . self::TYPE_STRING . "' or '" . self::TYPE_NUMBER . "'");
+        }
     }
 }

--- a/src/Exception/MalformedException.php
+++ b/src/Exception/MalformedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ByJG\AnyDataset\Text\Exception;
+
+use Exception;
+
+class MalformedException extends Exception
+{
+    
+}

--- a/src/FixedTextFileDataset.php
+++ b/src/FixedTextFileDataset.php
@@ -24,15 +24,10 @@ class FixedTextFileDataset
      * Text File Data Set
      *
      * @param string $source
-     * @param FixedTextDefinition[] $fieldDefinition
      * @throws NotFoundException
      */
-    public function __construct($source, $fieldDefinition)
+    protected function __construct($source)
     {
-        if (!is_array($fieldDefinition)) {
-            throw new InvalidArgumentException("You must define an array of FixedTextDefinition class.");
-        }
-
         $this->source = $source;
         $this->sourceType = "HTTP";
 
@@ -43,8 +38,33 @@ class FixedTextFileDataset
 
             $this->sourceType = "FILE";
         }
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @param string $source
+     * @return FixedTextFileDataset
+     */
+    public static function getInstance($source)
+    {
+        return new FixedTextFileDataset($source);
+    }
+
+    /**
+     * @param FixedTextDefinition[] $fieldDefinition
+     * @return FixedTextFileDataset
+     */
+    public function withFieldDefinition($fieldDefinition)
+    {
+
+        if (!is_array($fieldDefinition)) {
+            throw new InvalidArgumentException("You must define an array of FixedTextDefinition class.");
+        }
 
         $this->fieldDefinition = $fieldDefinition;
+
+        return $this;
     }
 
     /**
@@ -55,6 +75,10 @@ class FixedTextFileDataset
      */
     public function getIterator()
     {
+        if (empty($this->fieldDefinition)) {
+            throw new InvalidArgumentException("Field definition is empty");
+        }
+
         if ($this->sourceType == "HTTP") {
             return $this->getIteratorHttp();
         }

--- a/src/FixedTextFileDataset.php
+++ b/src/FixedTextFileDataset.php
@@ -109,7 +109,7 @@ class FixedTextFileDataset
 
         try {
             fwrite($handle, $out);
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             fclose($handle);
             throw new DatasetException($ex->getMessage());
         }

--- a/src/FixedTextFileIterator.php
+++ b/src/FixedTextFileIterator.php
@@ -110,19 +110,19 @@ class FixedTextFileIterator extends GenericIterator
         for ($i = 0; $i < $cntDef; $i++) {
             $fieldDef = $fieldDefinition[$i];
 
-            $fields[$fieldDef->fieldName] = substr($buffer, $fieldDef->startPos, $fieldDef->length);
-            if (!empty($fieldDef->requiredValue)
-                && (
-                    !preg_match("/^[" . $fieldDef->requiredValue . "]$/", $fields[$fieldDef->fieldName])
-                )
-            ) {
+            $fields[$fieldDef->fieldName] = trim(substr($buffer, $fieldDef->startPos, $fieldDef->length));
+            if (!empty($fieldDef->requiredValue) && !in_array($fields[$fieldDef->fieldName], $fieldDef->requiredValue)) {
                 throw new IteratorException(
-                    "Expected the value '"
-                    . $fieldDef->requiredValue
+                    "Expected the values '"
+                    . implode(",", $fieldDef->requiredValue)
                     . "' and I got '"
                     . $fields[$fieldDef->fieldName]
                     . "'"
                 );
+            }
+
+            if (empty($fieldDef->subTypes) && $fieldDef->type == FixedTextDefinition::TYPE_NUMBER) {
+                $fields[$fieldDef->fieldName] = $fields[$fieldDef->fieldName] + 0; # Force convert to number
             }
 
             if (is_array($fieldDef->subTypes)) {

--- a/src/Formatter/CSVFormatter.php
+++ b/src/Formatter/CSVFormatter.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace ByJG\AnyDataset\Text\Formatter;
+
+use ByJG\AnyDataset\Core\Formatter\BaseFormatter;
+use ByJG\AnyDataset\Core\GenericIterator;
+
+class CSVFormatter extends BaseFormatter
+{
+    const APPLY_QUOTE_ALWAYS = 0;
+    const APPLY_QUOTE_WHEN_REQUIRED = 1;
+    const APPLY_QUOTE_ALL_STRINGS = 2;
+    const NEVER_APPLY_QUOTE = 3;
+
+    protected $delimiter = ",";
+    protected $quote = '"';
+    protected $applyQuote = null;
+    protected $outputHeader = true;
+
+    public function __construct($anydataset, $delimiter = ",", $quote = '"', $applyQuote = 1)
+    {
+        parent::__construct($anydataset);
+
+        $this->$delimiter = $delimiter;
+        $this->quote = $quote;
+        $this->applyQuote = $applyQuote;
+    }
+
+    protected function anydatasetRaw($iterator)
+    {
+        $lines = "";
+        if ($this->outputHeader) {
+            $row = $iterator->moveNext();
+            $lines .= $this->rowRaw(array_keys($row->toArray()));
+            $lines .= $this->rowRaw($row->toArray());
+        }
+
+        foreach ($iterator as $row) {
+            $lines .= $this->rowRaw($row->toArray());
+        }
+
+        return $lines;
+    }
+
+    protected function rowRaw($row)
+    {
+        $line = "";
+        foreach ($row as $key => $value) {
+            $value = str_replace($this->quote, $this->quote . $this->quote, $value);
+            $quote = 
+                ($this->getApplyQuote() == self::APPLY_QUOTE_ALWAYS)
+                || ($this->getApplyQuote() == self::APPLY_QUOTE_WHEN_REQUIRED && (!is_numeric($value) && (strpos($value, $this->quote) !== false || strpos($value, $this->delimiter) !== false)))
+                || ($this->getApplyQuote() == self::APPLY_QUOTE_ALL_STRINGS && !is_numeric($value))
+                ? $this->quote : "";
+            $line .= (!empty($line) ? $this->delimiter : "") . $quote . $value . $quote;
+        }
+        return $line . "\n";
+    }
+
+    public function raw()
+    {
+        if ($this->object instanceof GenericIterator) {
+            return $this->anydatasetRaw($this->object);
+        }
+        return $this->rowRaw($this->object->toArray());
+    }
+
+
+    public function toText()
+    {
+        return $this->raw();
+    }
+
+    public function setDelimiter($value) 
+    {
+        $this->delimiter = $value;
+    }
+
+    public function getDelimiter()
+    {
+        return $this->delimiter;
+    }
+
+    public function setQuote($value) 
+    {
+        $this->quote = $value;
+    }
+
+    public function getQuote()
+    {
+        return $this->quote;
+    }
+
+    public function setApplyQuote($value) 
+    {
+        $this->applyQuote = $value;
+    }
+
+    public function getApplyQuote()
+    {
+        return $this->applyQuote;
+    }
+    /**
+     * @return mixed
+     */
+    function getOutputHeader() {
+        return $this->outputHeader;
+    }
+    
+    /**
+     * @param bool $outputHeader 
+     */
+    function setOutputHeader($outputHeader) {
+        $this->outputHeader = $outputHeader;
+    }
+}

--- a/src/Formatter/FixedSizeColumnFormatter.php
+++ b/src/Formatter/FixedSizeColumnFormatter.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace ByJG\AnyDataset\Text\Formatter;
+
+use ByJG\AnyDataset\Core\AnyDataset;
+use ByJG\AnyDataset\Core\Formatter\BaseFormatter;
+use ByJG\AnyDataset\Text\Enum\FixedTextDefinition;
+use ByJG\AnyDataset\Text\Exception\MalformedException;
+
+class FixedSizeColumnFormatter extends BaseFormatter
+{
+    /**
+     * @var FixedTextDefinition[]
+     */
+    protected $fieldDefinition = null;
+    
+    /**
+     * @var string
+     */
+    protected $padNumber = '0';
+
+    protected $padString = " ";
+
+    public function __construct($anydataset, $fieldDefinition)
+    {
+        parent::__construct($anydataset);
+
+        $this->fieldDefinition = $fieldDefinition;
+    }
+
+    protected function anydatasetRaw($iterator)
+    {
+        $lines = "";
+        foreach ($iterator as $row) {
+            $lines .= $this->rowRaw($row->toArray());
+        }
+
+        return $lines;
+    }
+
+    protected function rowRaw($row, $fieldDefinition = null, $eof = "\n")
+    {
+        if (empty($fieldDefinition)) {
+            $fieldDefinition = $this->fieldDefinition;
+        } 
+        if (!is_array($fieldDefinition)) {
+            $fieldDefinition = [$fieldDefinition];
+        }
+
+        usort($fieldDefinition, function($a, $b) { return $a->startPos - $b->startPos; });
+       
+        $line = "";
+        foreach ($fieldDefinition as $definition) {
+            if (!isset($row[$definition->fieldName])) {
+                throw new MalformedException("Field '$definition->fieldName' doesn't exist");
+            }
+            $value = $row[$definition->fieldName];
+
+            if (strlen($value) > $definition->length) {
+                throw new MalformedException("Field '$definition->fieldName' has maximum size of $definition->length but I got " . strlen($value) . " characters.");
+            }
+            if (!empty($definition->requiredValue) && (!in_array($value, $definition->requiredValue))) {
+                throw new MalformedException("Field '$definition->fieldName' requires to be one of '" . implode(",", $definition->requiredValue) . "' but I found '$value'");
+            }
+
+            if ($definition->type == FixedTextDefinition::TYPE_NUMBER) {
+                $line .= str_pad($value, $definition->length, $this->padNumber, STR_PAD_LEFT);
+            } else {
+                $line .= str_pad($value, $definition->length, $this->padString, STR_PAD_RIGHT);
+            }
+
+            if (!empty($definition->subTypes)) {
+                $subTypes = $definition->subTypes;
+                if (is_array($definition->subTypes)) {
+                    if (!isset($definition->subTypes[$value])) {
+                        throw new MalformedException("Sub type '$value' doesn't exist");
+                    }
+                    $subTypes = $definition->subTypes[$value];
+                }
+                $line .= $this->rowRaw($row, $subTypes, "");
+            }
+        }
+        return $line . $eof;
+    }
+
+    public function raw()
+    {
+        if ($this->object instanceof AnyDataset) {
+            return $this->anydatasetRaw($this->object->getIterator());
+        }
+        return $this->rowRaw($this->object->toArray());
+    }
+
+
+    public function toText()
+    {
+        return $this->raw();
+    }
+
+
+	/**
+	 * 
+	 * @return string
+	 */
+	function getPadNumber() {
+		return $this->padNumber;
+	}
+	
+	/**
+	 * 
+	 * @param string $padNumber 
+	 */
+	function setPadNumber($padNumber) {
+		$this->padNumber = $padNumber;
+	}
+	/**
+	 * @return string
+	 */
+	function getPadString() {
+		return $this->padString;
+	}
+	
+	/**
+	 * @param string $padString 
+	 */
+	function setPadString($padString) {
+		$this->padString = $padString;
+	}
+}

--- a/src/TextFileIterator.php
+++ b/src/TextFileIterator.php
@@ -89,10 +89,18 @@ class TextFileIterator extends GenericIterator
             $cols = preg_split($this->fieldexpression, preg_replace("/(\r?\n?)$/", "", $this->currentBuffer), -1, PREG_SPLIT_DELIM_CAPTURE);
 
             $row = new Row();
+            $row->enableFieldNameCaseInSensitive();
 
+            // @todo review
             for ($i = 0; ($i < count($this->fields)) && ($i < count($cols)); $i++) {
-                $column = preg_replace("/^[\"'](.*)[\"']$/", "$1", $cols[$i]);
-                $row->addField(strtolower($this->fields[$i]), $column);
+                $column = $cols[$i];
+
+                if (($i >= count($this->fields) - 1) || ($i >= count($cols) - 1)) {
+                    $column = preg_replace("/(\r?\n?)$/", "", $column);
+                }
+                $column = preg_replace("/^[\"'](.*)[\"']$/", "$1", $column);
+
+                $row->addField($this->fields[$i], $column);
             }
 
             $this->readNextLine();

--- a/src/TextFileIterator.php
+++ b/src/TextFileIterator.php
@@ -86,17 +86,12 @@ class TextFileIterator extends GenericIterator
     public function moveNext()
     {
         if ($this->hasNext()) {
-            $cols = preg_split($this->fieldexpression, $this->currentBuffer, -1, PREG_SPLIT_DELIM_CAPTURE);
+            $cols = preg_split($this->fieldexpression, preg_replace("/(\r?\n?)$/", "", $this->currentBuffer), -1, PREG_SPLIT_DELIM_CAPTURE);
 
             $row = new Row();
 
             for ($i = 0; ($i < count($this->fields)) && ($i < count($cols)); $i++) {
-                $column = $cols[$i];
-
-                if (($i >= count($this->fields) - 1) || ($i >= count($cols) - 1)) {
-                    $column = preg_replace("/(\r?\n?)$/", "", $column);
-                }
-
+                $column = preg_replace("/^[\"'](.*)[\"']$/", "$1", $cols[$i]);
                 $row->addField(strtolower($this->fields[$i]), $column);
             }
 

--- a/tests/FixedTextFileDatasetTest.php
+++ b/tests/FixedTextFileDatasetTest.php
@@ -41,7 +41,8 @@ class FixedTextFileDatasetTest extends TestCase
             new FixedTextDefinition('code', 11, 4),
         ];
 
-        $repository = new FixedTextFileDataset(__DIR__ . '/sample-fixed.txt', $fieldDefinition);
+        $repository = FixedTextFileDataset::getInstance(__DIR__ . '/sample-fixed.txt')
+            ->withFieldDefinition($fieldDefinition);
 
         $this->assertEquals([
             0 => [
@@ -74,7 +75,8 @@ class FixedTextFileDatasetTest extends TestCase
             new FixedTextDefinition('code', 11, 4),
         ];
 
-        $repository = new FixedTextFileDataset(__DIR__ . '/sample-fixed.txt', $fieldDefinition);
+        $repository = FixedTextFileDataset::getInstance(__DIR__ . '/sample-fixed.txt')
+            ->withFieldDefinition($fieldDefinition);
         $repository->getIterator()->toArray();
     }
 
@@ -104,7 +106,8 @@ class FixedTextFileDatasetTest extends TestCase
             ),
         ];
 
-        $repository = new FixedTextFileDataset(__DIR__ . '/sample-fixed.txt', $fieldDefinition);
+        $repository = FixedTextFileDataset::getInstance(__DIR__ . '/sample-fixed.txt')
+            ->withFieldDefinition($fieldDefinition);
 
         $this->assertEquals([
             0 => [
@@ -151,7 +154,8 @@ class FixedTextFileDatasetTest extends TestCase
             ),
         ];
 
-        $repository = new FixedTextFileDataset(__DIR__ . '/sample-fixed.txt', $fieldDefinition);
+        $repository = FixedTextFileDataset::getInstance(__DIR__ . '/sample-fixed.txt')
+            ->withFieldDefinition($fieldDefinition);
         $repository->getIterator()->toArray();
     }
 
@@ -181,7 +185,8 @@ class FixedTextFileDatasetTest extends TestCase
             ),
         ];
 
-        $repository = new FixedTextFileDataset(__DIR__ . '/sample-fixed.txt', $fieldDefinition);
+        $repository = FixedTextFileDataset::getInstance(__DIR__ . '/sample-fixed.txt')
+            ->withFieldDefinition($fieldDefinition);
         $repository->getIterator()->toArray();
     }
 }

--- a/tests/FixedTextFileDatasetTest.php
+++ b/tests/FixedTextFileDatasetTest.php
@@ -4,6 +4,7 @@ namespace Tests\AnyDataset\Dataset;
 
 use ByJG\AnyDataset\Text\FixedTextFileDataset;
 use ByJG\AnyDataset\Text\Enum\FixedTextDefinition;
+use ByJG\AnyDataset\Core\Exception\IteratorException;
 use PHPUnit\Framework\TestCase;
 
 class FixedTextFileDatasetTest extends TestCase
@@ -13,24 +14,6 @@ class FixedTextFileDatasetTest extends TestCase
      * @var FixedTextFileDataset
      */
     protected $object;
-
-    /**
-     * Sets up the fixture, for example, opens a network connection.
-     * This method is called before a test is executed.
-     */
-    protected function setUp()
-    {
-
-    }
-
-    /**
-     * Tears down the fixture, for example, closes a network connection.
-     * This method is called after a test is executed.
-     */
-    protected function tearDown()
-    {
-
-    }
 
     public function testGetIterator()
     {
@@ -63,11 +46,12 @@ class FixedTextFileDatasetTest extends TestCase
     /**
      * @throws \ByJG\AnyDataset\Core\Exception\DatasetException
      * @throws \ByJG\AnyDataset\Core\Exception\NotFoundException
-     * @expectedException \ByJG\AnyDataset\Core\Exception\IteratorException
-     * @expectedExceptionMessage Expected the value
      */
     public function testGetIteratorException()
     {
+        $this->expectException(IteratorException::class);
+        $this->expectExceptionMessage("Expected the value");
+
         $fieldDefinition = [
             new FixedTextDefinition('id', 0, 3),
             new FixedTextDefinition('name', 3, 7),
@@ -129,11 +113,12 @@ class FixedTextFileDatasetTest extends TestCase
     /**
      * @throws \ByJG\AnyDataset\Core\Exception\DatasetException
      * @throws \ByJG\AnyDataset\Core\Exception\NotFoundException
-     * @expectedException \ByJG\AnyDataset\Core\Exception\IteratorException
-     * @expectedExceptionMessage Subtype does not match
      */
     public function testGetIterator_SubTypes_Exception()
     {
+        $this->expectException(IteratorException::class);
+        $this->expectExceptionMessage("Subtype does not match");
+
         $fieldDefinition = [
             new FixedTextDefinition('id', 0, 3),
             new FixedTextDefinition('name', 3, 7),
@@ -162,11 +147,12 @@ class FixedTextFileDatasetTest extends TestCase
     /**
      * @throws \ByJG\AnyDataset\Core\Exception\DatasetException
      * @throws \ByJG\AnyDataset\Core\Exception\NotFoundException
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Subtype needs to be an array
      */
     public function testGetIterator_SubTypes_Exception_Param()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Subtype needs to be an array");
+
         $fieldDefinition = [
             new FixedTextDefinition('id', 0, 3),
             new FixedTextDefinition('name', 3, 7),

--- a/tests/FixedTextFileDatasetTest.php
+++ b/tests/FixedTextFileDatasetTest.php
@@ -2,9 +2,14 @@
 
 namespace Tests\AnyDataset\Dataset;
 
+use ByJG\AnyDataset\Core\AnyDataset;
+use ByJG\AnyDataset\Core\Exception\IteratorException;
+use ByJG\AnyDataset\Core\Row;
 use ByJG\AnyDataset\Text\FixedTextFileDataset;
 use ByJG\AnyDataset\Text\Enum\FixedTextDefinition;
-use ByJG\AnyDataset\Core\Exception\IteratorException;
+use ByJG\AnyDataset\Text\Exception\MalformedException;
+use ByJG\AnyDataset\Text\Formatter\FixedSizeColumnFormatter;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class FixedTextFileDatasetTest extends TestCase
@@ -18,27 +23,27 @@ class FixedTextFileDatasetTest extends TestCase
     public function testGetIterator()
     {
         $fieldDefinition = [
-            new FixedTextDefinition('id', 0, 3),
+            new FixedTextDefinition('id', 0, 3, FixedTextDefinition::TYPE_NUMBER),
             new FixedTextDefinition('name', 3, 7),
-            new FixedTextDefinition('enable', 10, 1, 'S|N'),
-            new FixedTextDefinition('code', 11, 4),
+            new FixedTextDefinition('enable', 10, 1, FixedTextDefinition::TYPE_STRING, ['S', 'N']),
+            new FixedTextDefinition('code', 11, 4, FixedTextDefinition::TYPE_NUMBER),
         ];
 
         $repository = FixedTextFileDataset::getInstance(__DIR__ . '/sample-fixed.txt')
             ->withFieldDefinition($fieldDefinition);
 
-        $this->assertEquals([
+        $this->assertSame([
             0 => [
-                'id' => '001',
-                'name' => 'JOAO   ',
+                'id' => 1,
+                'name' => 'JOAO',
                 'enable' => 'S',
-                'code' => '1520'
+                'code' => 1520
             ],
             1 => [
-                'id' => '002',
+                'id' => 2,
                 'name' => 'GILBERT',
                 'enable' => 'N',
-                'code' => '1621'
+                'code' => 1621
             ]
             ], $repository->getIterator()->toArray());
     }
@@ -55,7 +60,7 @@ class FixedTextFileDatasetTest extends TestCase
         $fieldDefinition = [
             new FixedTextDefinition('id', 0, 3),
             new FixedTextDefinition('name', 3, 7),
-            new FixedTextDefinition('enable', 10, 1,'Y|N'),
+            new FixedTextDefinition('enable', 10, 1, FixedTextDefinition::TYPE_STRING, ['Y', 'N']),
             new FixedTextDefinition('code', 11, 4),
         ];
 
@@ -71,17 +76,18 @@ class FixedTextFileDatasetTest extends TestCase
     public function testGetIterator_SubTypes()
     {
         $fieldDefinition = [
-            new FixedTextDefinition('id', 0, 3),
+            new FixedTextDefinition('id', 0, 3, FixedTextDefinition::TYPE_NUMBER),
             new FixedTextDefinition('name', 3, 7),
             new FixedTextDefinition(
                 'enable',
                 10,
                 1,
+                FixedTextDefinition::TYPE_STRING,
                 null,
                 [
                     "S" => [
-                        new FixedTextDefinition('first', 11, 1),
-                        new FixedTextDefinition('second', 12, 3),
+                        new FixedTextDefinition('first', 11, 1, FixedTextDefinition::TYPE_NUMBER),
+                        new FixedTextDefinition('second', 12, 3, FixedTextDefinition::TYPE_NUMBER),
                     ],
                     "N" => [
                         new FixedTextDefinition('reason', 11, 4),
@@ -93,16 +99,16 @@ class FixedTextFileDatasetTest extends TestCase
         $repository = FixedTextFileDataset::getInstance(__DIR__ . '/sample-fixed.txt')
             ->withFieldDefinition($fieldDefinition);
 
-        $this->assertEquals([
+        $this->assertSame([
             0 => [
-                'id' => '001',
-                'name' => 'JOAO   ',
+                'id' => 1,
+                'name' => 'JOAO',
                 'enable' => 'S',
-                'first' => '1',
-                'second' => '520'
+                'first' => 1,
+                'second' => 520
             ],
             1 => [
-                'id' => '002',
+                'id' => 2,
                 'name' => 'GILBERT',
                 'enable' => 'N',
                 'reason' => '1621'
@@ -126,6 +132,7 @@ class FixedTextFileDatasetTest extends TestCase
                 'enable',
                 10,
                 1,
+                FixedTextDefinition::TYPE_STRING,
                 null,
                 [
                     "Y" => [
@@ -150,7 +157,7 @@ class FixedTextFileDatasetTest extends TestCase
      */
     public function testGetIterator_SubTypes_Exception_Param()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Subtype needs to be an array");
 
         $fieldDefinition = [
@@ -160,6 +167,7 @@ class FixedTextFileDatasetTest extends TestCase
                 'enable',
                 10,
                 1,
+                FixedTextDefinition::TYPE_STRING,
                 null,
                 [
                     "S" => [
@@ -175,4 +183,198 @@ class FixedTextFileDatasetTest extends TestCase
             ->withFieldDefinition($fieldDefinition);
         $repository->getIterator()->toArray();
     }
+
+    public function testRowFormatter_1()
+    {
+        $fieldDefinition = [
+            new FixedTextDefinition('name', 3, 7),
+            new FixedTextDefinition('id', 0, 3, FixedTextDefinition::TYPE_NUMBER),
+            new FixedTextDefinition('enable', 10, 1, FixedTextDefinition::TYPE_STRING, ['S', 'N']),
+            new FixedTextDefinition('code', 11, 4),
+        ];
+
+        $row = new Row([
+            "id" => 1,
+            "name" => "Joao",
+            "enable" => "N",
+            "code" => 1520
+        ]);
+        $formatter = new FixedSizeColumnFormatter($row, $fieldDefinition);
+        $this->assertEquals("001Joao   N1520\n", $formatter->toText());
+    }
+
+    public function testRowFormatter_1_Error_1()
+    {
+        $this->expectException(MalformedException::class);
+        $this->expectExceptionMessage("Field 'enable' requires to be one of 'S,N' but I found 'X'");
+
+        $fieldDefinition = [
+            new FixedTextDefinition('name', 3, 7),
+            new FixedTextDefinition('id', 0, 3),
+            new FixedTextDefinition('enable', 10, 1, FixedTextDefinition::TYPE_STRING, ['S', 'N']),
+            new FixedTextDefinition('code', 11, 4),
+        ];
+
+        $row = new Row([
+            "id" => 1,
+            "name" => "Joao",
+            "enable" => "X",
+            "code" => 1520
+        ]);
+        $formatter = new FixedSizeColumnFormatter($row, $fieldDefinition);
+        $formatter->toText();
+    }
+
+    public function testRowFormatter_1_Error_2()
+    {
+        $this->expectException(MalformedException::class);
+        $this->expectExceptionMessage("Field 'name' has maximum size of 7 but I got 15 characters.");
+
+        $fieldDefinition = [
+            new FixedTextDefinition('name', 3, 7),
+            new FixedTextDefinition('id', 0, 3),
+            new FixedTextDefinition('enable', 10, 1, FixedTextDefinition::TYPE_STRING, ['S', 'N']),
+            new FixedTextDefinition('code', 11, 4),
+        ];
+
+        $row = new Row([
+            "id" => 1,
+            "name" => "Name Big Enough",
+            "enable" => "S",
+            "code" => 1520
+        ]);
+        $formatter = new FixedSizeColumnFormatter($row, $fieldDefinition);
+        $formatter->toText();
+    }
+
+    public function testRowFormatter_1_Error_3()
+    {
+        $this->expectException(MalformedException::class);
+        $this->expectExceptionMessage("Field 'id' doesn't exist");
+
+        $fieldDefinition = [
+            new FixedTextDefinition('name', 3, 7),
+            new FixedTextDefinition('id', 0, 3),
+            new FixedTextDefinition('enable', 10, 1, FixedTextDefinition::TYPE_STRING, ['S', 'N']),
+            new FixedTextDefinition('code', 11, 4),
+        ];
+
+        $row = new Row([
+            "name" => "Name Big Enough",
+            "enable" => "S",
+            "code" => 1520
+        ]);
+        $formatter = new FixedSizeColumnFormatter($row, $fieldDefinition);
+        $this->assertEquals("001Joao   N1520\n", $formatter->toText());
+    }
+
+    public function testRowFormatter_2()
+    {
+        $fieldDefinition = [
+            new FixedTextDefinition('id', 0, 3, FixedTextDefinition::TYPE_NUMBER),
+            new FixedTextDefinition('name', 3, 7),
+            new FixedTextDefinition(
+                'enable',
+                10,
+                1,
+                FixedTextDefinition::TYPE_STRING,
+                null,
+                [
+                    "S" => [
+                        new FixedTextDefinition('first', 11, 1),
+                        new FixedTextDefinition('second', 12, 3),
+                    ],
+                    "N" => new FixedTextDefinition('reason', 11, 4)
+                ]
+            ),
+        ];
+    
+        $row = new Row([
+            "id" => 1,
+            "name" => "Joao",
+            "enable" => "N",
+            "reason" => "NONE",
+        ]);
+        $formatter = new FixedSizeColumnFormatter($row, $fieldDefinition);
+        $this->assertEquals("001Joao   NNONE\n", $formatter->toText());
+
+        $row = new Row([
+            "id" => 1,
+            "name" => "Joao",
+            "enable" => "S",
+            "first" => "1",
+            "second" => 520
+        ]);
+        $formatter = new FixedSizeColumnFormatter($row, $fieldDefinition);
+        $this->assertEquals("001Joao   S1520\n", $formatter->toText());
+    }
+
+    public function testRowFormatter_2_Error_1()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Type must be 'string' or 'number'");
+
+        $fieldDefinition = [
+            new FixedTextDefinition('id', 0, 3),
+            new FixedTextDefinition('name', 3, 7),
+            new FixedTextDefinition(
+                'enable',
+                10,
+                1,
+                null,   # <--- Error
+                null,
+                [
+                    "S" => [
+                        new FixedTextDefinition('first', 11, 1),
+                        new FixedTextDefinition('second', 12, 3),
+                    ],
+                    "N" => new FixedTextDefinition('reason', 11, 4)
+                ]
+            ),
+        ];
+    
+        $row = new Row([
+            "id" => 1,
+            "name" => "Joao",
+            "enable" => "X",
+            "reason" => "NONE",
+        ]);
+        $formatter = new FixedSizeColumnFormatter($row, $fieldDefinition);
+        $formatter->toText();
+    }
+
+    public function testRowFormatter_2_Error_2()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Required Value must be empty or an ARRAY of values");
+
+        $fieldDefinition = [
+            new FixedTextDefinition('id', 0, 3),
+            new FixedTextDefinition('name', 3, 7),
+            new FixedTextDefinition(
+                'enable',
+                10,
+                1,
+                FixedTextDefinition::TYPE_STRING,
+                "S",    # <--- Error
+                [
+                    "S" => [
+                        new FixedTextDefinition('first', 11, 1),
+                        new FixedTextDefinition('second', 12, 3),
+                    ],
+                    "N" => new FixedTextDefinition('reason', 11, 4)
+                ]
+            ),
+        ];
+    
+        $row = new Row([
+            "id" => 1,
+            "name" => "Joao",
+            "enable" => "X",
+            "reason" => "NONE",
+        ]);
+        $formatter = new FixedSizeColumnFormatter($row, $fieldDefinition);
+        $formatter->toText();
+    }
+
 }

--- a/tests/TextFileDatasetTest.php
+++ b/tests/TextFileDatasetTest.php
@@ -20,7 +20,7 @@ class TextFileDatasetTest extends TestCase
 
     const REMOTEURL = "https://opensource-test-resources.web.app/%s";
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fileName_Unix = sys_get_temp_dir() . "/textfiletest-unix.csv";
         self::$fileName_Windows = sys_get_temp_dir() . "/textfiletest-windows.csv";
@@ -64,25 +64,13 @@ class TextFileDatasetTest extends TestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         unlink(self::$fileName_Unix);
         unlink(self::$fileName_Windows);
         unlink(self::$fileName_MacClassic);
         unlink(self::$fileName_BlankLine);
         unlink(self::$firstline_Header);
-    }
-
-    // Run before each test case
-    public function setUp()
-    {
-        // Nothing Here
-    }
-
-    // Run end each test case
-    public function teardown()
-    {
-        // Nothing Here
     }
 
     public function testcreateTextFileData_Unix()
@@ -299,28 +287,25 @@ class TextFileDatasetTest extends TestCase
         $this->assertEquals($count, 2000);
     }
 
-    /**
-     * @expectedException \ByJG\AnyDataset\Core\Exception\NotFoundException
-     */
     public function testfileNotFound()
     {
+        $this->expectException(\ByJG\AnyDataset\Core\Exception\NotFoundException::class);
+
         TextFileDataset::getInstance("/tmp/xyz");
     }
 
-    /**
-     * @expectedException \ByJG\AnyDataset\Core\Exception\DatasetException
-     */
     public function testremoteFileNotFound()
     {
+        $this->expectException(\ByJG\AnyDataset\Core\Exception\DatasetException::class);
+
         $txtFile = TextFileDataset::getInstance(self::REMOTEURL . "notfound-test");
         $txtFile->getIterator();
     }
 
-    /**
-     * @expectedException \ByJG\AnyDataset\Core\Exception\DatasetException
-     */
     public function testserverNotFound()
     {
+        $this->expectException(\ByJG\AnyDataset\Core\Exception\DatasetException::class);
+
         $txtFile = TextFileDataset::getInstance("http://notfound-test/alalal");
         $txtFile->getIterator();
     }

--- a/tests/TextFileDatasetTest.php
+++ b/tests/TextFileDatasetTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\AnyDataset\Dataset;
 
+use ByJG\AnyDataset\Core\AnyDataset;
 use ByJG\AnyDataset\Core\GenericIterator;
 use ByJG\AnyDataset\Core\IteratorInterface;
 use ByJG\AnyDataset\Core\Row;
+use ByJG\AnyDataset\Text\Formatter\CSVFormatter;
 use ByJG\AnyDataset\Text\TextFileDataset;
 use PHPUnit\Framework\TestCase;
 
@@ -60,7 +62,7 @@ class TextFileDatasetTest extends TestCase
         // A lot of extras fields
         self::$fieldNames = array();
         for ($i = 1; $i < 30; $i++) {
-            self::$fieldNames[] = "field$i";
+            self::$fieldNames[] = "Field$i";
         }
     }
 
@@ -310,7 +312,83 @@ class TextFileDatasetTest extends TestCase
         $txtFile->getIterator();
     }
 
-    /**
+    public function testRowCSVFormatter()
+    {
+        $row = new Row([
+            "field1" => "value1",
+            "field2" => "0.345",
+            "field3" => 0.874,
+            "field4" => 10,
+            "field5" => 'With"Quote',
+            "field6" => "With'SingleQuote",
+            "field7" => "value7",
+            "field8" => "val,ue7",
+            "field9" => "value9",
+        ]);
+
+        $formatter = new CSVFormatter($row);
+
+        $this->assertEquals('value1,0.345,0.874,10,"With""Quote",With\'SingleQuote,value7,"val,ue7",value9' . "\n", $formatter->toText());
+
+        $formatter->setApplyQuote(CSVFormatter::APPLY_QUOTE_ALL_STRINGS);
+        $this->assertEquals('"value1",0.345,0.874,10,"With""Quote","With\'SingleQuote","value7","val,ue7","value9"' . "\n", $formatter->toText());
+
+        $formatter->setApplyQuote(CSVFormatter::APPLY_QUOTE_ALWAYS);
+        $this->assertEquals('"value1","0.345","0.874","10","With""Quote","With\'SingleQuote","value7","val,ue7","value9"' . "\n", $formatter->toText());
+    }
+
+    public function testAnyDatasetRowFormatter()
+    {
+        $anydataset = TextFileDataset::getInstance(self::$fileName_Unix)
+            ->withFields(self::$fieldNames);
+        $formatter = new CSVFormatter($anydataset->getIterator());
+
+        $text = "field1,field2,field3\n";
+        for ($i = 1; $i <= 2000; $i++) {
+            $text .= "$i,STRING$i,VALUE$i\n";
+        }
+        // print_r($formatter->toText());
+        $this->assertEquals($text, $formatter->toText());
+
+        $text = '"field1","field2","field3"' . "\n";
+        for ($i = 1; $i <= 2000; $i++) {
+            $text .= "$i,\"STRING$i\",\"VALUE$i\"\n";
+        }
+
+        $anydataset = TextFileDataset::getInstance(self::$fileName_Unix)
+            ->withFields(self::$fieldNames);
+        $formatter = new CSVFormatter($anydataset->getIterator());
+        $formatter->setApplyQuote(CSVFormatter::APPLY_QUOTE_ALL_STRINGS);
+        $this->assertEquals($text, $formatter->toText());
+
+        $text = '"field1","field2","field3"' . "\n";
+        for ($i = 1; $i <= 2000; $i++) {
+            $text .= "\"$i\",\"STRING$i\",\"VALUE$i\"\n";
+        }
+
+        $anydataset = TextFileDataset::getInstance(self::$fileName_Unix)
+            ->withFields(self::$fieldNames);
+        $formatter = new CSVFormatter($anydataset->getIterator());
+        $formatter->setApplyQuote(CSVFormatter::APPLY_QUOTE_ALWAYS);
+        $this->assertEquals($text, $formatter->toText());
+    }
+
+    public function testAnyDatasetRowFormatterNoHeader()
+    {
+        $anydataset = TextFileDataset::getInstance(self::$fileName_Unix)
+            ->withFields(self::$fieldNames);
+        $formatter = new CSVFormatter($anydataset->getIterator());
+        $formatter->setOutputHeader(false);
+
+        $text = "";
+        for ($i = 1; $i <= 2000; $i++) {
+            $text .= "$i,STRING$i,VALUE$i\n";
+        }
+        // print_r($formatter->toText());
+        $this->assertEquals($text, $formatter->toText());
+    }
+
+        /**
      * @param Row $sr
      */
     public function assertSingleRow($sr, $count)


### PR DESCRIPTION
Remove arguments from TextFileDataset constructor and implement `withFields(array)` and `withFieldParsert(parser)`
Remove arguments from FixedTextFileDataset constructor and implement `withFieldDefinition($fieldDefinition)`
Added field type to FixedTextDefinition class
Improved Sub_Type parse in the FixedTextFileDataset class
Added CSVFormatter class
Added FixedSizeColumnFormatter class
